### PR TITLE
Use community for cancel tradeoffers instead of API

### DIFF
--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -420,12 +420,46 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 		return;
 	}
 
-	this.manager._apiCall('POST', this.isOurOffer ? 'CancelTradeOffer' : 'DeclineTradeOffer', 1, {"tradeofferid": this.id}, (err) => {
+	this.manager._community.httpRequestPost(`https://steamcommunity.com/tradeoffer/${this.id}/${this.isOurOffer ? 'cancel' : 'decline'}`, {
+		/*"headers": {
+			"referer": `https://steamcommunity.com/tradeoffer/${(this.id || 'new')}/?partner=${this.partner.accountid}` + (this._token ? "&token=" + this._token : '')
+		},*/ // check if referrer is needed
+		"json": true,
+		"form": {
+			"sessionid": this.manager._community.getSessionID()
+		},
+		"checkJsonError": false,
+		"checkHttpError": false // we'll check it ourself. Some trade offer errors return HTTP 500
+	}, (err, response, body) => {
 		if (err) {
 			Helpers.makeAnError(err, callback);
 			return;
 		}
+		
+		if (response.statusCode != 200) {
+			if (response.statusCode == 401) {
+				this.manager._community._notifySessionExpired(new Error("HTTP error 401"));
+				Helpers.makeAnError(new Error("Not Logged In"), callback);
+				return;
+			}
+			
+			Helpers.makeAnError(new Error("HTTP error " + response.statusCode), callback, body);
+			return;
+		}
 
+		if (!body) {
+			Helpers.makeAnError(new Error("Malformed JSON response"), callback);
+			return;
+		}
+
+		if (body && body.strError) {
+			Helpers.makeAnError(null, callback, body);
+			return;
+		}
+
+		if (body && body.tradeofferid !== this.id) {
+			Helpers.makeAnError("Wrong response", callback);
+		}
 		this.state = this.isOurOffer ? ETradeOfferState.Canceled : ETradeOfferState.Declined;
 		this.updated = new Date();
 
@@ -434,7 +468,7 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 		}
 
 		this.manager.doPoll();
-	});
+	}, "tradeoffermanager");
 };
 
 TradeOffer.prototype.accept = function(skipStateUpdate, callback) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -61,11 +61,11 @@ function offerSuperMalformed(offer) {
 
 function offerMalformed(offer) {
 	return offerSuperMalformed(offer) || ((offer.items_to_give || []).length == 0 && (offer.items_to_receive || []).length == 0);
-};
+}
 
 function processItems(items) {
 	return items.map(item => new EconItem(item));
-};
+}
 
 exports.offerSuperMalformed = offerSuperMalformed;
 exports.offerMalformed = offerMalformed;

--- a/lib/index.js
+++ b/lib/index.js
@@ -471,43 +471,64 @@ TradeOfferManager.prototype.getOffers = function(filter, historicalCutoff, callb
 		"language": this._language,
 		"active_only": (filter == EOfferFilter.ActiveOnly) ? 1 : 0,
 		"historical_only": (filter == EOfferFilter.HistoricalOnly) ? 1 : 0,
-		"time_historical_cutoff": Math.floor(historicalCutoff.getTime() / 1000)
+		"time_historical_cutoff": Math.floor(historicalCutoff.getTime() / 1000),
+		"cursor": 0
 	};
 
-	this._apiCall('GET', 'GetTradeOffers', 1, options, (err, body) => {
-		if (err) {
-			callback(err);
-			return;
-		}
+	var sentOffers = [];
+	var receivedOffers = [];
 
-		if (!body.response) {
-			callback(new Error("Malformed API response"));
-			return;
-		}
+	var request = () => {
+		this._apiCall('GET', 'GetTradeOffers', 1, options, (err, body) => {
+			if (err) {
+				callback(err);
+				return;
+			}
 
-		// Make sure at least some offers are well-formed. Apparently some offers can be empty just forever. Because Steam.
-		var allOffers = (body.response.trade_offers_sent || []).concat(body.response.trade_offers_received || []);
-		if (allOffers.length > 0 && (allOffers.every(Helpers.offerMalformed) || allOffers.some(Helpers.offerSuperMalformed))) {
-			callback(new Error("Data temporarily unavailable"));
-			return;
-		}
+			if (!body.response) {
+				callback(new Error("Malformed API response"));
+				return;
+			}
 
+			// Make sure at least some offers are well-formed. Apparently some offers can be empty just forever. Because Steam.
+			var allOffers = (body.response.trade_offers_sent || []).concat(body.response.trade_offers_received || []);
+			if (allOffers.length > 0 && (allOffers.every(Helpers.offerMalformed) || allOffers.some(Helpers.offerSuperMalformed))) {
+				callback(new Error("Data temporarily unavailable"));
+				return;
+			}
+
+			sentOffers = sentOffers.concat(body.response.trade_offers_sent || []);
+			receivedOffers = receivedOffers.concat(body.response.trade_offers_received || []);
+
+			options.cursor = body.response.next_cursor || 0;
+			if (typeof options.cursor == 'number' && options.cursor != 0) {
+				this.emit('debug', 'GetTradeOffers with cursor ' + options.cursor);
+				request();
+			} else {
+				finish();
+			}
+		});
+	};
+
+	var finish = () => {
 		//manager._digestDescriptions(body.response.descriptions);
 
 		// Let's check the asset cache and see if we have descriptions that match these items.
 		// If the necessary descriptions aren't in the asset cache, this will request them from the WebAPI and store
 		// them for future use.
-		Helpers.checkNeededDescriptions(this, (body.response.trade_offers_sent || []).concat(body.response.trade_offers_received || []), (err) => {
+		Helpers.checkNeededDescriptions(this, sentOffers.concat(receivedOffers), (err) => {
 			if (err) {
 				callback(new Error("Descriptions: " + err.message));
 				return;
 			}
 
-			var sent = (body.response.trade_offers_sent || []).map(data => Helpers.createOfferFromData(this, data));
-			var received = (body.response.trade_offers_received || []).map(data => Helpers.createOfferFromData(this, data));
+			var sent = sentOffers.map(data => Helpers.createOfferFromData(this, data));
+			var received = receivedOffers.map(data => Helpers.createOfferFromData(this, data));
 
 			callback(null, sent, received);
 			this.emit('offerList', filter, sent, received);
 		});
-	});
+	};
+
+	request();
 };

--- a/lib/polling.js
+++ b/lib/polling.js
@@ -52,6 +52,7 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 	}
 
 	this.emit('debug', 'Doing trade offer poll since ' + offersSince + (fullUpdate ? ' (full update)' : ''));
+	var requestStart = Date.now();
 	this.getOffers(fullUpdate ? EOfferFilter.All : EOfferFilter.ActiveOnly, new Date(offersSince * 1000), (err, sent, received) => {
 		if (err) {
 			this.emit('debug', "Error getting trade offers for poll: " + err.message);
@@ -59,6 +60,8 @@ TradeOfferManager.prototype.doPoll = function(doFullUpdate) {
 			this._resetPollTimer();
 			return;
 		}
+
+		this.emit('debug', 'Trade offer poll succeeded in ' + (Date.now() - requestStart) + ' ms');
 
 		var origPollData = JSON.parse(JSON.stringify(this.pollData)); // deep clone
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "steam-tradeoffer-manager",
-	"version": "2.10.3",
+	"version": "2.10.4",
 	"description": "A simple trade offers API for Steam",
 	"main": "./lib/index.js",
 	"repository": {


### PR DESCRIPTION
This pull request changes `cancel` and `decline` for tradeoffers, so that it uses steamcommunity instead of API, because the endpoints were removed.