### PR TITLE
Use community for cancel tradeoffers instead of API 

### DIFF
--- a/lib/classes/TradeOffer.js
+++ b/lib/classes/TradeOffer.js
@@ -420,12 +420,46 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 		return;
 	}
 
-	this.manager._apiCall('POST', this.isOurOffer ? 'CancelTradeOffer' : 'DeclineTradeOffer', 1, {"tradeofferid": this.id}, (err) => {
+	this.manager._community.httpRequestPost(`https://steamcommunity.com/tradeoffer/${this.id}/${this.isOurOffer ? 'cancel' : 'decline'}`, {
+		/*"headers": {
+			"referer": `https://steamcommunity.com/tradeoffer/${(this.id || 'new')}/?partner=${this.partner.accountid}` + (this._token ? "&token=" + this._token : '')
+		},*/ // check if referrer is needed
+		"json": true,
+		"form": {
+			"sessionid": this.manager._community.getSessionID()
+		},
+		"checkJsonError": false,
+		"checkHttpError": false // we'll check it ourself. Some trade offer errors return HTTP 500
+	}, (err, response, body) => {
 		if (err) {
 			Helpers.makeAnError(err, callback);
 			return;
 		}
+		
+		if (response.statusCode != 200) {
+			if (response.statusCode == 401) {
+				this.manager._community._notifySessionExpired(new Error("HTTP error 401"));
+				Helpers.makeAnError(new Error("Not Logged In"), callback);
+				return;
+			}
+			
+			Helpers.makeAnError(new Error("HTTP error " + response.statusCode), callback, body);
+			return;
+		}
 
+		if (!body) {
+			Helpers.makeAnError(new Error("Malformed JSON response"), callback);
+			return;
+		}
+
+		if (body && body.strError) {
+			Helpers.makeAnError(null, callback, body);
+			return;
+		}
+
+		if (body && body.tradeofferid !== this.id) {
+			Helpers.makeAnError("Wrong response", callback);
+		}
 		this.state = this.isOurOffer ? ETradeOfferState.Canceled : ETradeOfferState.Declined;
 		this.updated = new Date();
 
@@ -434,7 +468,7 @@ TradeOffer.prototype.cancel = TradeOffer.prototype.decline = function(callback) 
 		}
 
 		this.manager.doPoll();
-	});
+	}, "tradeoffermanager");
 };
 
 TradeOffer.prototype.accept = function(skipStateUpdate, callback) {


### PR DESCRIPTION
This pull request changes `cancel` and `decline` for tradeoffers, so that it uses steamcommunity instead of API, because the endpoints were removed.